### PR TITLE
Update dependabot for pip instead of npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: 'chore(deps)'
+      prefix: "chore(deps)"
     assignees:
       - NotTheRealWallyx


### PR DESCRIPTION
## Description

Dependabot is still trying to look for npm dependencies to do the update check.

Closes #3 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [ ] Documentation
- [x] Other (please describe)

DevOps

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if relevant)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Screenshots (if applicable)
